### PR TITLE
make unit test actually work for x86 hasher

### DIFF
--- a/hash_matcher/CMakeLists.txt
+++ b/hash_matcher/CMakeLists.txt
@@ -5,6 +5,7 @@
     list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
     add_executable($ENV{CMPROJ} main.cpp)
+    add_library($ENV{CMPROJ}-lib main.cpp)
     include(./$ENV{ARCH}/CMakeLists.txt)
     include(./$ENV{ARCH}/Packing.cmake)
 

--- a/hash_matcher/main.cpp
+++ b/hash_matcher/main.cpp
@@ -1,3 +1,4 @@
+#define CATCH_CONFIG_RUNNER // Configure catch to use your main, and not its own.
 #include <iostream>
 #include <fstream>
 #include <sstream>
@@ -5,8 +6,9 @@
 #include <iomanip>
 #include <vector>
 #include <cstdlib>
+#include "main.h"
 
-int add(int a, int b) {
+int addd(int a, int b) {
         return a + b;
     }
 

--- a/hash_matcher/test/CMakeLists.txt
+++ b/hash_matcher/test/CMakeLists.txt
@@ -1,15 +1,11 @@
     #cmake list for unit test integrations
     include(AddCatch2)
     
-    add_executable(
-      unit_tests
-      test_calc.cpp
-    )
-    target_link_libraries(
-      unit_tests PRIVATE calculator Catch2::Catch2WithMain
-    )
+    add_executable(unit_tests test_calc.cpp)
+    target_link_libraries(unit_tests PRIVATE $ENV{CMPROJ}-lib Catch2::Catch2WithMain)
+ 
     
     include(CTest)
     include(Catch)
-    catch_discover_tests(unit_tests)
+    ###catch_discover_tests(unit_tests)
 

--- a/hash_matcher/test/test_calc.cpp
+++ b/hash_matcher/test/test_calc.cpp
@@ -1,8 +1,23 @@
 //working example from https://github.com/rutura/CMakeSeries/tree/main/Ep023
 //file will be completely replaced
 #include <catch2/catch_test_macros.hpp>
-#include "calculator.h"
+//////#include "calculator.h"
+#include "../main.h"
+#include "../main.cpp"
+//////#include <catch.hpp>
 
+TEST_CASE("Pass Tests")
+{
+    REQUIRE(1 == 1);
+}
+
+TEST_CASE("Fail test")
+{
+    REQUIRE(1 == 0);
+}
+
+//////these are not needed rn
+/*
 TEST_CASE("CalculatorTest - Add", "[Calculator]") {
     Calculator calc;
     REQUIRE(calc.add(2, 3) == 5);
@@ -35,3 +50,4 @@ TEST_CASE("CalculatorTest - Mod", "[Calculator]") {
     REQUIRE(calc.mod(6, 4) == 2);
     REQUIRE(calc.mod(5, 2) == 1);
 }
+*/


### PR DESCRIPTION
Problem was catch_discover_tests(unit_tests) should NOT be present in current design.